### PR TITLE
Use two spaces for indentation

### DIFF
--- a/account/configure-account.rb
+++ b/account/configure-account.rb
@@ -14,9 +14,9 @@ client = Nexmo::Client.new(
 )
 
 result = client.account.update(
-    moHttpUrl: SMS_CALLBACK_URL
+  moHttpUrl: SMS_CALLBACK_URL
 )
 
 result.to_h.each do |key, value|
-    puts "#{key}: #{value}"
+  puts "#{key}: #{value}"
 end

--- a/verify/check.rb
+++ b/verify/check.rb
@@ -6,14 +6,14 @@ NEXMO_API_SECRET = ENV['NEXMO_API_SECRET']
 
 REQUEST_ID = ARGV[0]
 if REQUEST_ID.empty?
-    puts 'Please supply the `request_id'
-    exit
+  puts 'Please supply the `request_id'
+  exit
 end
 
 CODE = ARGV[1]
 if CODE.empty?    
-    puts 'Please supply the confirmation code'
-    exit
+  puts 'Please supply the confirmation code'
+  exit
 end
 
 require 'nexmo'

--- a/verify/search.rb
+++ b/verify/search.rb
@@ -6,8 +6,8 @@ NEXMO_API_SECRET = ENV['NEXMO_API_SECRET']
 
 REQUEST_ID = ARGV[0]
 if REQUEST_ID.empty?
-    puts 'Please supply the `request_id'
-    exit
+  puts 'Please supply the `request_id'
+  exit
 end
 
 require 'nexmo'

--- a/verify/trigger_next_event.rb
+++ b/verify/trigger_next_event.rb
@@ -6,8 +6,8 @@ NEXMO_API_SECRET = ENV['NEXMO_API_SECRET']
 
 REQUEST_ID = ARGV[0]
 if REQUEST_ID.empty?
-    puts 'Please supply the `request_id'
-    exit
+  puts 'Please supply the `request_id'
+  exit
 end
 
 require 'nexmo'

--- a/voice/download-a-recording.rb
+++ b/voice/download-a-recording.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 response = client.files.save(RECORDING_URL, 'recording.mp3')

--- a/voice/earmuff-a-call.rb
+++ b/voice/earmuff-a-call.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 client.calls.earmuff(UUID)

--- a/voice/mute-a-call.rb
+++ b/voice/mute-a-call.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 client.calls.mute(UUID)

--- a/voice/play-audio-stream-into-call.rb
+++ b/voice/play-audio-stream-into-call.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
     
 AUDIO_URL = 'https://nexmo-community.github.io/ncco-examples/assets/voice_api_audio_streaming.mp3'

--- a/voice/play-dtmf-into-call.rb
+++ b/voice/play-dtmf-into-call.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 DIGITS = '332393'

--- a/voice/play-text-to-speech-into-a-call.rb
+++ b/voice/play-text-to-speech-into-a-call.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 response = client.calls.talk.start(UUID, text: 'Hello from Nexmo', voice_name: "Kimberly")

--- a/voice/record-a-call-with-split-audio.rb
+++ b/voice/record-a-call-with-split-audio.rb
@@ -20,24 +20,24 @@ helpers do
 end
 
 route :get, :post, '/webhooks/answer' do
-    [
+  [
+    {
+      "action": "record",
+      "split": "conversation",
+      "channels": 2,
+      "eventUrl": ["#{request.base_url}/webhooks/recordings"]
+    },
+    {
+      "action": "connect",
+      "from": NEXMO_NUMBER,
+      "endpoint": [
         {
-          "action": "record",
-          "split": "conversation",
-          "channels": 2,
-          "eventUrl": ["#{request.base_url}/webhooks/recordings"]
-        },
-        {
-          "action": "connect",
-          "from": NEXMO_NUMBER,
-          "endpoint": [
-            {
-              "type": "phone",
-              "number": TO_NUMBER
-            }
-          ]
+          "type": "phone",
+          "number": TO_NUMBER
         }
-      ].to_json
+      ]
+    }
+  ].to_json
 end
 
 route :get, :post, '/webhooks/recordings' do

--- a/voice/record-a-conversation.rb
+++ b/voice/record-a-conversation.rb
@@ -15,16 +15,16 @@ end
 CONF_NAME = "record-a-conversation"
 
 route :get, :post, '/webhooks/answer' do
-    [
-        {
-          action: "conversation",
-          name: CONF_NAME,
-          record: "true",
-          #This currently needs to be set rather than default due to a known issue https://help.nexmo.com/hc/en-us/articles/360001162687
-          eventMethod: "POST", 
-          eventUrl: ["#{request.base_url}/webhooks/recordings"]
-        }
-      ].to_json
+  [
+    {
+      action: "conversation",
+      name: CONF_NAME,
+      record: "true",
+      #This currently needs to be set rather than default due to a known issue https://help.nexmo.com/hc/en-us/articles/360001162687
+      eventMethod: "POST", 
+      eventUrl: ["#{request.base_url}/webhooks/recordings"]
+    }
+  ].to_json
 end
 
 route :get, :post, '/webhooks/recordings' do

--- a/voice/record-a-message.rb
+++ b/voice/record-a-message.rb
@@ -13,23 +13,23 @@ helpers do
 end
 
 route :get, :post, '/webhooks/answer' do
-    [
-        {
-            "action": "talk",
-            "text": "Please leave a message after the tone, then press #. We will get back to you as soon as we can"
-        },
-        {
-            "action": "record",
-            "eventUrl": ["#{request.base_url}/webhooks/recordings"],
-            "endOnSilence": "3",
-            "endOnKey": "#",
-            "beepStart": "true"
-        },
-        {
-            "action": "talk",
-            "text": "Thank you for your message. Goodbye"
-        }
-      ].to_json
+  [
+    {
+      "action": "talk",
+      "text": "Please leave a message after the tone, then press #. We will get back to you as soon as we can"
+    },
+    {
+      "action": "record",
+      "eventUrl": ["#{request.base_url}/webhooks/recordings"],
+      "endOnSilence": "3",
+      "endOnKey": "#",
+      "beepStart": "true"
+    },
+    {
+      "action": "talk",
+      "text": "Thank you for your message. Goodbye"
+    }
+  ].to_json
 end
 
 route :get, :post, '/webhooks/recordings' do

--- a/voice/retrieve-info-for-a-call.rb
+++ b/voice/retrieve-info-for-a-call.rb
@@ -8,8 +8,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 response = client.calls.get(NEXMO_CALL_UUID)

--- a/voice/retrieve-info-for-all-calls.rb
+++ b/voice/retrieve-info-for-all-calls.rb
@@ -9,8 +9,8 @@ require 'nexmo'
 require 'time'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 now = Time.now
@@ -20,5 +20,5 @@ response = client.calls.list({date_start: yesterday.utc.iso8601, date_end: now.u
 
 calls = response._embedded.calls
 calls.each do |call|
-    puts call.inspect
+  puts call.inspect
 end

--- a/voice/transfer-a-call.rb
+++ b/voice/transfer-a-call.rb
@@ -9,8 +9,8 @@ NEXMO_APPLICATION_PRIVATE_KEY_PATH = ENV['NEXMO_APPLICATION_PRIVATE_KEY_PATH']
 require 'nexmo'
 
 client = Nexmo::Client.new(
-    application_id: NEXMO_APPLICATION_ID,
-    private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
+  application_id: NEXMO_APPLICATION_ID,
+  private_key: File.read(NEXMO_APPLICATION_PRIVATE_KEY_PATH)
 )
 
 ncco = {"type": "ncco", "url": ["https://developer.nexmo.com/ncco/transfer.json"]}


### PR DESCRIPTION
Inconsistent indentation is harder to read. Two spaces is standard in Ruby.