### PR TITLE
remove condition check in Verify examples

### DIFF
--- a/verify/cancel.rb
+++ b/verify/cancel.rb
@@ -16,9 +16,3 @@ client = Nexmo::Client.new(
 )
 
 response = client.verify.cancel(REQUEST_ID)
-
-if response.status == '0'
-  puts 'Verification cancelled.'
-else
-  puts response.error_text
-end

--- a/verify/check.rb
+++ b/verify/check.rb
@@ -27,11 +27,9 @@ response = client.verify.check(
 )
 
 # when the check is successful
-if response.status == '0'
+if response
   # the cost of this verification
   puts response.price
   # the currency ofthe cost
   puts response.currency
-else
-  puts response.error_text
 end

--- a/verify/request.rb
+++ b/verify/request.rb
@@ -15,9 +15,7 @@ response = client.verify.request(
   brand: 'AcmeInc'
 )
 
-if response.status == '0'
+if response
   # display the Verify `request_id`
   puts response.request_id
-else
-  puts response.error_text
 end

--- a/verify/request_with_workflow.rb
+++ b/verify/request_with_workflow.rb
@@ -24,9 +24,7 @@ response = client.verify.request(
   workflow_id: WORKFLOW_ID
 )
 
-if response.status == '0'
+if response
   # display the Verify `request_id`
   puts response.request_id
-else
-  puts response.error_text
 end

--- a/verify/search.rb
+++ b/verify/search.rb
@@ -17,10 +17,8 @@ client = Nexmo::Client.new(
 
 response = client.verify.search(request_id: REQUEST_ID)
 
-if !response.error_text
+if response
   # The current status of this request, for example:
   # => IN PROGRESS
   puts response.status
-else
-  puts response.error_text
 end

--- a/verify/trigger_next_event.rb
+++ b/verify/trigger_next_event.rb
@@ -17,8 +17,6 @@ client = Nexmo::Client.new(
 
 response = client.verify.trigger_next_event(REQUEST_ID)
 
-if response.status == '0'
-  puts 'Next event triggered'
-else
+if response
   puts response.error_text
 end


### PR DESCRIPTION
Per the upcoming [Ruby SDK release](https://github.com/Nexmo/nexmo-ruby/milestone/17), the SDK now handles error checks for APIs that return an error code inside a `200 OK` HTTP status. The code snippets no longer need to reflect a condition check for that.