### PR TITLE
add PSD2 code snippets

### DIFF
--- a/verify/send_psd2_code.rb
+++ b/verify/send_psd2_code.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'dotenv/load'
+require 'nexmo'
+
+NEXMO_API_KEY = ENV['NEXMO_API_KEY']
+NEXMO_API_SECRET = ENV['NEXMO_API_SECRET']
+TO_NUMBER = ENV['TO_NUMBER']
+
+client = Nexmo::Client.new(
+  api_key: NEXMO_API_KEY,
+  api_secret: NEXMO_API_SECRET
+)
+
+response = client.verify.psd2(
+  number: TO_NUMBER,
+  payee: 'AcmeInc',
+  amount: 12.34
+)
+
+if response
+  # display the Verify PSD2 `request_id`
+  puts response.request_id
+end

--- a/verify/send_psd2_code_with_workflow.rb
+++ b/verify/send_psd2_code_with_workflow.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dotenv/load'
+require 'nexmo'
+
+NEXMO_API_KEY = ENV['NEXMO_API_KEY']
+NEXMO_API_SECRET = ENV['NEXMO_API_SECRET']
+TO_NUMBER = ENV['TO_NUMBER']
+
+WORKFLOW_ID = ARGV[0]
+if WORKFLOW_ID.empty?
+  puts 'Please supply the workflow_id'
+  exit
+end
+
+client = Nexmo::Client.new(
+  api_key: NEXMO_API_KEY,
+  api_secret: NEXMO_API_SECRET
+)
+
+response = client.verify.psd2(
+  number: TO_NUMBER,
+  payee: 'AcmeInc',
+  amount: 12.34,
+  workflow_id: WORKFLOW_ID
+)
+
+if response
+  # display the Verify PSD2 `request_id`
+  puts response.request_id
+end


### PR DESCRIPTION
Create Ruby code snippets for PSD2 endpoint, both with and without a workflow ID

**Note**: These examples will not work until https://github.com/Nexmo/nexmo-ruby/pull/162 is merged into the Ruby SDK and v7.1.0 is released.