### PR TITLE
rename methods to applications from applications_v2

### DIFF
--- a/application/create-application.rb
+++ b/application/create-application.rb
@@ -12,7 +12,7 @@ client = Nexmo::Client.new(
 )
 
 begin
-  response = client.applications_v2.create(
+  response = client.applications.create(
     name: 'Code Example App',
     capabilities: {
       'messages': {

--- a/application/delete-application.rb
+++ b/application/delete-application.rb
@@ -14,7 +14,7 @@ client = Nexmo::Client.new(
 )
 
 begin
-  response = client.applications_v2.delete(NEXMO_APPLICATION_ID)
+  response = client.applications.delete(NEXMO_APPLICATION_ID)
   puts 'OK' if response == :no_content
 rescue StandardError => e
   puts e.message

--- a/application/get-application.rb
+++ b/application/get-application.rb
@@ -14,7 +14,7 @@ client = Nexmo::Client.new(
 )
 
 begin
-  response = client.applications_v2.get(NEXMO_APPLICATION_ID)
+  response = client.applications.get(NEXMO_APPLICATION_ID)
   puts "#{response.name}: #{response.id}"
 rescue StandardError => e
   puts e.message

--- a/application/list-applications.rb
+++ b/application/list-applications.rb
@@ -11,7 +11,7 @@ client = Nexmo::Client.new(
   api_secret: NEXMO_API_SECRET
 )
 
-response = client.applications_v2.list
+response = client.applications.list
 
 response._embedded.applications.each do |application|
   puts "#{application.name}: #{application.id}"

--- a/application/update-application.rb
+++ b/application/update-application.rb
@@ -14,7 +14,7 @@ client = Nexmo::Client.new(
 )
 
 begin
-  response = client.applications_v2.update(
+  response = client.applications.update(
     NEXMO_APPLICATION_ID,
     id: NEXMO_APPLICATION_ID,
     name: 'Ruby Update App',


### PR DESCRIPTION
`applications_v2` was renamed to `applications` in the SDK a little while back, but we missed renaming these snippets, uncovered them doing an audit this afternoon. 